### PR TITLE
Just a small pull

### DIFF
--- a/pyGBot/core.py
+++ b/pyGBot/core.py
@@ -539,13 +539,15 @@ class GBotFactory(protocol.ClientFactory):
     def clientConnectionLost(self, connector, reason):
         """ Called when a client's connection is shut down. Attempts to
         reconnect to the server. """
-
+        log.logger.error('connection lost: %s', (str(reason),))
+        time.sleep(5)
         connector.connect()
 
     def clientConnectionFailed(self, connector, reason):
         """ Called when a client's connection fails. Log the error and exit. """
         log.logger.critical('connection failed: %s', (str(reason),))
-        reactor.stop()
+        time.sleep(5)
+        connector.connect()
 
 def run():
     """ Run GBot. Called from the pyGBot bootstrap script. """


### PR DESCRIPTION
I noticed the bot wasn't reconnecting properly on my test server, looked into the issue, and found this offending bit of code. I reworked it to wait five seconds and try an automatic reconnect instead of permanently shutting down the Twisted reactor on "critical errors" (which included temporary connection refusals or routing issues). Might add a configurable reconnect timer later.
